### PR TITLE
Fix for Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 Umbraco Tinifier 2.0
+
+**Notice: This package addresses several issues preventing TinifierNext from running. Since the author/owner of that package are not reachable, this new package was created instead.**
+
+## Overview
+The official and free Umbraco [TinyPNG][tp] package for image compressing. Tinifier allows to dramatically reduce the size of PNG and JPEG images which positively influences  page loading time.
+
+[TinyPNG][tp] uses smart lossy compression techniques to reduce the file size of your PNG files. By selectively decreasing the number of colors in the image, fewer bytes are required to store the data. The effect is nearly invisible, but it makes a huge difference in file size. 
+
+[TinyPNG][tp] provides an API which allows compressing images programmatically. 500 successful requests per month are available for free usage. It can be not enough for large enterprise websites, so check prices on the TinyPNG website before the start.
+
+## Quick start [(download .pdf with screens)][qs]
+*(the pdf is outdated, but the principals still apply)*
+1. Install Tinifier2 package
+2. Register account in the [TinyPNG][tp] and get API key
+3. Add the Tinifier section for your user in the Users section.
+4. Go to the Tinifier settings and set API key.
+5. Tinify (compress) an appropriate image 
+6. Your visitors are happy with fast loading pages!
+
+
+## Features
+- Optimize individual images from the Media
+- Folder optimization
+- Supported image formats: PNG and JPEG
+- Optimized image stats 
+- API requests widget
+- Total saved bytes widget
+- Image optimization on upload
+- Umbraco 8 support
+- Azure blob storage support
+- Top 50 tinified images
+- Save metadata
+- Optimize ImageCropper images on upload
+- Tinify everything (all media and crops)
+- Organize images by dates in Media
+
+## Nuget package
+https://www.nuget.org/packages/Our.Umbraco.Tinifier
+
+## License
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+[bd]: http://backend-devs.com/
+[tp]: https://tinypng.com
+[qs]: https://our.umbraco.org/FileDownload?id=17908

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Umbraco Tinifier 2.0
+# Umbraco Tinifier 2.0
 
 **Notice: This package addresses several issues preventing TinifierNext from running. Since the author/owner of that package are not reachable, this new package was created instead.**
 

--- a/Tinifier.Core/Application/DBStartup.cs
+++ b/Tinifier.Core/Application/DBStartup.cs
@@ -10,6 +10,7 @@ using Umbraco.Core.Services;
 
 namespace Tinifier.Core.Application
 {
+    [ComposeBefore(typeof(tinifierStartup))]
     public class DbComposer : IUserComposer
     {
         public void Compose(Composition composition)

--- a/Tinifier.Core/Application/UmbracoStartup.cs
+++ b/Tinifier.Core/Application/UmbracoStartup.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Hosting;
 using System.Xml;
+using Newtonsoft.Json.Linq;
 using Tinifier.Core.Infrastructure;
 using Tinifier.Core.Infrastructure.Exceptions;
 using Tinifier.Core.Models.Db;
@@ -44,7 +44,7 @@ namespace Tinifier.Core.Application
         private readonly IImageService _imageService;
         private readonly IHistoryService _historyService;
         private readonly IImageCropperInfoService _imageCropperInfoService;
-        private readonly TSetting settings;
+        private TSetting settings;
 
         public SectionService(IFileSystemProviderRepository fileSystemProviderRepository, ISettingsService settingsService,
             IStatisticService statisticService, IImageService imageService, IHistoryService historyService,
@@ -56,13 +56,14 @@ namespace Tinifier.Core.Application
             _imageService = imageService;
             _historyService = historyService;
             _imageCropperInfoService = imageCropperInfoService;
-
-            settings = _settingsService.GetSettings();
         }
 
         public void Initialize()
         {          
             SetFileSystemProvider();
+
+            settings = _settingsService.GetSettings();
+
             ServerVariablesParser.Parsing += Parsing;
             TreeControllerBase.MenuRendering += MenuRenderingHandler;
 

--- a/Tinifier.Core/Application/UmbracoStartup.cs
+++ b/Tinifier.Core/Application/UmbracoStartup.cs
@@ -44,20 +44,24 @@ namespace Tinifier.Core.Application
         private readonly IImageService _imageService;
         private readonly IHistoryService _historyService;
         private readonly IImageCropperInfoService _imageCropperInfoService;
+        private readonly TSetting settings;
 
         public SectionService(IFileSystemProviderRepository fileSystemProviderRepository, ISettingsService settingsService,
-            IStatisticService statisticService, IImageService imageService, IHistoryService historyService)
+            IStatisticService statisticService, IImageService imageService, IHistoryService historyService,
+            IImageCropperInfoService imageCropperInfoService)
         {
             _fileSystemProviderRepository = fileSystemProviderRepository;
             _settingsService = settingsService;
             _statisticService = statisticService;
             _imageService = imageService;
             _historyService = historyService;
-            // _imageCropperInfoService = imageCropperInfoService;
+            _imageCropperInfoService = imageCropperInfoService;
+
+            settings = _settingsService.GetSettings();
         }
 
         public void Initialize()
-        {
+        {          
             SetFileSystemProvider();
             ServerVariablesParser.Parsing += Parsing;
             TreeControllerBase.MenuRendering += MenuRenderingHandler;
@@ -68,8 +72,6 @@ namespace Tinifier.Core.Application
 
             MediaService.Deleted += MediaService_Deleted;
             MediaService.EmptiedRecycleBin += MediaService_EmptiedRecycleBin;
-
-            ServerVariablesParser.Parsing += Parsing;
         }
 
         private void MediaService_Deleted(IMediaService sender, DeleteEventArgs<IMedia> e)
@@ -91,7 +93,6 @@ namespace Tinifier.Core.Application
         /// <param name="e">RecycleBinEventArgs</param>
         private void MediaService_EmptiedRecycleBin(IMediaService sender, RecycleBinEventArgs e)
         {
-
             //foreach (var id in e.)
             //{
             //    _historyService.Delete(id.ToString());
@@ -102,8 +103,7 @@ namespace Tinifier.Core.Application
 
         private void ContentService_Saving(IContentService sender, SaveEventArgs<IContent> e)
         {
-            var settingService = _settingsService.GetSettings();
-            if (settingService == null)
+            if (settings == null)
                 return;
 
             foreach (var entity in e.SavedEntities)
@@ -137,7 +137,7 @@ namespace Tinifier.Core.Application
 
                     //Cropped file was created or updated
                     _imageCropperInfoService.GetCropImagesAndTinify(key, imageCropperInfo, imagePath,
-                        settingService.EnableOptimizationOnUpload, path);
+                        settings.EnableOptimizationOnUpload, path);
                 }
             }
         }
@@ -251,7 +251,6 @@ namespace Tinifier.Core.Application
 
         private void SetFileSystemProvider()
         {
-
             var path = HostingEnvironment.MapPath("~/Web.config");
             var doc = new XmlDocument();
             doc.Load(path);

--- a/Tinifier.Core/Controllers/TinifierController.cs
+++ b/Tinifier.Core/Controllers/TinifierController.cs
@@ -282,6 +282,11 @@ namespace Tinifier.Core.Controllers
             var n = imagesList.Count();
             var k = n - nonOptimizedImagesCount;
 
+            if (n > 0)
+            {
+                _imageService.UpdateStatistics();
+            }
+
             return GetSuccessResponse(k, n,
                 nonOptimizedImagesCount == 0 ? EventMessageType.Success : EventMessageType.Warning);
         }

--- a/Tinifier.Core/Infrastructure/SolutionExtensions.cs
+++ b/Tinifier.Core/Infrastructure/SolutionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
 using Umbraco.Web;
 
@@ -48,11 +49,9 @@ namespace Tinifier.Core.Infrastructure
         /// <returns></returns>
         public static string GetAbsoluteUrl(Media uMedia)
         {
-            var url = uMedia.GetUrl("Image", null);
-            UmbracoHelper umbHelper = Umbraco.Web.Composing.Current.UmbracoHelper;
-            var content = umbHelper.Media(uMedia.Id);
-            var imagerUrl = content?.Url;
-            return imagerUrl;
+            var url = uMedia.GetUrl("umbracoFile", Current.Logger);
+
+            return url;
         }
     }
 }

--- a/Tinifier.Core/Repository/Common/IUmbracoDbRepository.cs
+++ b/Tinifier.Core/Repository/Common/IUmbracoDbRepository.cs
@@ -1,5 +1,6 @@
 ﻿using NPoco;
 using NPoco.fastJSON;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,11 +39,19 @@ namespace Tinifier.Core.Repository.Common
                 if (serializedRootObject != null)
                 {
                     RootObject rootObject = JSON.ToObject<RootObject>(serializedRootObject);
-                    var umbracoFile = rootObject.properties.umbracoFile.FirstOrDefault();
-                    if (umbracoFile != null)
+                    //If properties == null, we run into problems. Better to process what we can and ignore "corrupt" media items
+                    if (rootObject?.properties?.umbracoFile != null)
                     {
-                        Val valModel = JSON.ToObject<Val>(umbracoFile.val);
-                        return valModel.src;
+                        var umbracoFile = rootObject.properties.umbracoFile.FirstOrDefault();
+                        if (umbracoFile != null)
+                        {
+                            Val valModel = JSON.ToObject<Val>(umbracoFile.val);
+                            return valModel.src;
+                        }
+                    }
+                    else
+                    {
+                        Log.Error($"Tinifier - Error finding rootObject for id {id}");
                     }
                 }
             }

--- a/Tinifier.Core/Repository/FileSystemProvider/TFileSystemProviderRepository.cs
+++ b/Tinifier.Core/Repository/FileSystemProvider/TFileSystemProviderRepository.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using NPoco;
 using Tinifier.Core.Models.Db;
-using Umbraco.Core;
-using Umbraco.Core.Persistence;
 using Umbraco.Core.Scoping;
 
 namespace Tinifier.Core.Repository.FileSystemProvider
@@ -23,11 +21,18 @@ namespace Tinifier.Core.Repository.FileSystemProvider
                 Type = type
             };
 
-            using (IScope scope = _scopeProvider.CreateScope())
+            try
             {
-                var database = scope.Database;
-                database.Insert(settings);
-                scope.Complete();
+                using (IScope scope = _scopeProvider.CreateScope())
+                {
+                    var database = scope.Database;
+                    database.Insert(settings);
+                    scope.Complete();
+                }
+            }
+            catch
+            {
+                //Assume table doesn't exist yet
             }
         }
 
@@ -53,12 +58,19 @@ namespace Tinifier.Core.Repository.FileSystemProvider
 
         public void Delete()
         {
-            using (IScope scope = _scopeProvider.CreateScope())
+            try
             {
-                var database = scope.Database;
-                var query = new Sql("DELETE FROM TinifierFileSystemProviderSettings");
-                database.Execute(query);
-                scope.Complete();
+                using (IScope scope = _scopeProvider.CreateScope())
+                {
+                    var database = scope.Database;
+                    var query = new Sql("DELETE FROM TinifierFileSystemProviderSettings");
+                    database.Execute(query);
+                    scope.Complete();
+                }
+            }
+            catch 
+            { 
+                //Assume table doesn't exist yet
             }
         }
     }

--- a/Tinifier.Core/Repository/Image/IImageRepository.cs
+++ b/Tinifier.Core/Repository/Image/IImageRepository.cs
@@ -27,9 +27,9 @@ namespace Tinifier.Core.Repository.Image
 
         IEnumerable<Media> GetItemsFromFolder(int folderId);
 
-        int AmounthOfItems();
+        int AmountOfItems();
 
-        int AmounthOfOptimizedItems();
+        int AmountOfOptimizedItems();
 
         Media Get(string path);
     }

--- a/Tinifier.Core/Repository/Settings/TSettingsRepository.cs
+++ b/Tinifier.Core/Repository/Settings/TSettingsRepository.cs
@@ -22,11 +22,19 @@ namespace Tinifier.Core.Repository.Settings
         /// <returns></returns>
         public TSetting GetSettings()
         {
-            using (IScope scope = _scopeProvider.CreateScope())
+            try
             {
-                var database = scope.Database;
-                var query = new Sql("SELECT * FROM TinifierUserSettings ORDER BY Id DESC");
-                return database.FirstOrDefault<TSetting>(query);
+                using (IScope scope = _scopeProvider.CreateScope())
+                {
+                    var database = scope.Database;
+                    var query = new Sql("SELECT * FROM TinifierUserSettings ORDER BY Id DESC");
+                    return database.FirstOrDefault<TSetting>(query);
+                }
+            }
+            catch 
+            {
+                //Assume table hasn't been created yet
+                return null;
             }
         }
 

--- a/Tinifier.Core/Services/BlobStorage/AzureBlobStorageService.cs
+++ b/Tinifier.Core/Services/BlobStorage/AzureBlobStorageService.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+﻿using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,27 +16,32 @@ namespace Tinifier.Core.Services.BlobStorage
 
         public void SetDataForBlobStorage()
         {
-            var path = HostingEnvironment.MapPath("~/Web.config");
-            var doc = new XmlDocument();
-            doc.Load(path);
-            var node = doc.SelectSingleNode("appSettings");
-
-            if (node != null)
+            if (_blobContainer == null)
             {
-                var keysNodes = node.LastChild.SelectNodes("add");
-                var dictionary = new Dictionary<string, string>();
+                var path = HostingEnvironment.MapPath("~/Web.config");
+                var doc = new XmlDocument();
+                doc.Load(path);
+                var node = doc.SelectSingleNode("//appSettings");
 
-                foreach (XmlNode xmlNode in keysNodes)
-                    dictionary.Add(xmlNode.Attributes.GetNamedItem("key").Value,
-                        xmlNode.Attributes.GetNamedItem("value").Value);
+                if (node != null)
+                {
+                    var keysNodes = node.SelectNodes("add");
+                    var dictionary = new Dictionary<string, string>();
 
-                var connectionString = dictionary.First(x => x.Key == "connectionString").Value;
-                var containerName = dictionary.First(x => x.Key == "containerName").Value;
+                    foreach (XmlNode xmlNode in keysNodes)
+                    {
+                        dictionary.Add(xmlNode.Attributes.GetNamedItem("key").Value,
+                            xmlNode.Attributes.GetNamedItem("value").Value);
+                    }
 
-                var storageAccount = CloudStorageAccount.Parse(connectionString);
-                _blobClient = storageAccount.CreateCloudBlobClient();
-                _containerName = containerName;
-                _blobContainer = _blobClient.GetContainerReference(containerName);
+                    var connectionString = dictionary.First(x => x.Key == "AzureBlobFileSystem.ConnectionString:media").Value;
+                    var containerName = dictionary.First(x => x.Key == "AzureBlobFileSystem.ContainerName:media").Value;
+
+                    var storageAccount = CloudStorageAccount.Parse(connectionString);
+                    _blobClient = storageAccount.CreateCloudBlobClient();
+                    _containerName = containerName;
+                    _blobContainer = _blobClient.GetContainerReference(containerName);
+                }
             }
         }
 

--- a/Tinifier.Core/Services/BlobStorage/IBlobStorage.cs
+++ b/Tinifier.Core/Services/BlobStorage/IBlobStorage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.WindowsAzure.Storage.Blob;
+﻿using Microsoft.Azure.Storage.Blob;
 using System.Collections.Generic;
 
 namespace Tinifier.Core.Services.BlobStorage

--- a/Tinifier.Core/Services/FileSystem/FileSystemRegistrationService.cs
+++ b/Tinifier.Core/Services/FileSystem/FileSystemRegistrationService.cs
@@ -19,25 +19,29 @@ namespace Tinifier.Core.Services.FileSystem
         {
             IFileSystem fileSystem = null;
 
-            if (_fileSystemProviderRepository.GetFileSystem().Type == "PhysicalFileSystem")
+            var fs = _fileSystemProviderRepository.GetFileSystem();
+            if (fs != null)
             {
-                fileSystem = new PhysicalFileSystem("~/media");
-            }
-            else
-            {
-                try
+                if (fs.Type == "PhysicalFileSystem")
                 {
-                    fileSystem = AzureFileSystem.GetInstance(
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.ContainerName:media"],
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.RootUrl:media"],
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.ConnectionString:media"],
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.MaxDays:media"],
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.UseDefaultRoute:media"],
-                        ConfigurationManager.AppSettings["AzureBlobFileSystem.UsePrivateContainer:media"]);
+                    fileSystem = new PhysicalFileSystem("~/media");
                 }
-                catch (Exception e)
+                else
                 {
-                    Console.WriteLine(e);
+                    try
+                    {
+                        fileSystem = AzureFileSystem.GetInstance(
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.ContainerName:media"],
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.RootUrl:media"],
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.ConnectionString:media"],
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.MaxDays:media"],
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.UseDefaultRoute:media"],
+                            ConfigurationManager.AppSettings["AzureBlobFileSystem.UsePrivateContainer:media"]);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
                 }
             }
 

--- a/Tinifier.Core/Services/Media/IImageService.cs
+++ b/Tinifier.Core/Services/Media/IImageService.cs
@@ -77,6 +77,8 @@ namespace Tinifier.Core.Services.Media
         /// <param name="image">TImage</param>
         void UpdateImageAfterSuccessfullRequest(TinyResponse tinyResponse, TImage image, IFileSystem fs);
 
+        void UpdateStatistics();
+
         TImage GetCropImage(string path);
 
         void UndoTinify(int mediaId);

--- a/Tinifier.Core/Services/Media/ImageService.cs
+++ b/Tinifier.Core/Services/Media/ImageService.cs
@@ -270,9 +270,15 @@ namespace Tinifier.Core.Services.Media
             // update umbraco media attributes
             _imageRepository.Update(id, tinyResponse.Output.Size);
             // update statistic
-            _statisticService.UpdateStatistic();
+            //Try to limit the amount of times the statistics are gathered
+            //_statisticService.UpdateStatistic();
             // update tinifying state
             _stateService.UpdateState();
+        }
+
+        public void UpdateStatistics()
+        {
+            _statisticService.UpdateStatistic();
         }
 
         private TImage GetImage(uMedia uMedia)

--- a/Tinifier.Core/Services/Media/ImageService.cs
+++ b/Tinifier.Core/Services/Media/ImageService.cs
@@ -77,7 +77,9 @@ namespace Tinifier.Core.Services.Media
 
         public IEnumerable<TImage> Convert(IEnumerable<uModels.Media> items)
         {
-            return items.Select(x => Convert(x));
+            return items
+                .Select(x => Convert(x))
+                .Where(x => !string.IsNullOrEmpty(x.AbsoluteUrl)); //Skip images for which we were unable to fetch the Url
         }
 
         public TImage Convert(uModels.Media uMedia)

--- a/Tinifier.Core/Services/Statistic/StatisticService.cs
+++ b/Tinifier.Core/Services/Statistic/StatisticService.cs
@@ -20,8 +20,8 @@ namespace Tinifier.Core.Services.Statistic
         {
            var newStat = new TImageStatistic
            {
-               TotalNumberOfImages = _imageRepository.AmounthOfItems(),
-               NumberOfOptimizedImages = _imageRepository.AmounthOfOptimizedItems(),
+               TotalNumberOfImages = _imageRepository.AmountOfItems(),
+               NumberOfOptimizedImages = _imageRepository.AmountOfOptimizedItems(),
                TotalSavedBytes = 0
            };
 
@@ -47,8 +47,8 @@ namespace Tinifier.Core.Services.Statistic
         {
             var statistic = _statisticRepository.GetStatistic() ?? CreateInitialStatistic();
 
-            statistic.TotalNumberOfImages = _imageRepository.AmounthOfItems();
-            statistic.NumberOfOptimizedImages = _imageRepository.AmounthOfOptimizedItems();
+            statistic.TotalNumberOfImages = _imageRepository.AmountOfItems();
+            statistic.NumberOfOptimizedImages = _imageRepository.AmountOfOptimizedItems();
             statistic.TotalSavedBytes = _statisticRepository.GetTotalSavedBytes();
 
             _statisticRepository.Update(statistic);
@@ -58,8 +58,8 @@ namespace Tinifier.Core.Services.Statistic
         {
             var statistic = _statisticRepository.GetStatistic() ?? CreateInitialStatistic();
 
-            statistic.TotalNumberOfImages = _imageRepository.AmounthOfItems() - amount;
-            statistic.NumberOfOptimizedImages = _imageRepository.AmounthOfOptimizedItems();
+            statistic.TotalNumberOfImages = _imageRepository.AmountOfItems() - amount;
+            statistic.NumberOfOptimizedImages = _imageRepository.AmountOfOptimizedItems();
             statistic.TotalSavedBytes = _statisticRepository.GetTotalSavedBytes();
 
             _statisticRepository.Update(statistic);

--- a/Tinifier.Core/Tinifier.Core.csproj
+++ b/Tinifier.Core/Tinifier.Core.csproj
@@ -331,6 +331,8 @@
     <Compile Include="Repository\Statistic\TStatisticRepository.cs" />
     <Compile Include="Services\BackendDevs\BackendDevsConnectorService.cs" />
     <Compile Include="Services\BackendDevs\IBackendDevsConnector.cs" />
+    <Compile Include="Services\BlobStorage\AzureBlobStorageService.cs" />
+    <Compile Include="Services\BlobStorage\IBlobStorage.cs" />
     <Compile Include="Services\FileSystem\FileSystemRegistrationService.cs" />
     <Compile Include="Services\FileSystem\IFileSystemRegistrationService.cs" />
     <Compile Include="Services\History\HistoryService.cs" />


### PR DESCRIPTION
This pull request address a few issues that prevented Tinifier2 from working in Umbraco 8. 
(https://github.com/dimonser147/UmbracoTinifier2/issues/1)
- 1 or more (possibly corrupt) media items were preventing the entire batch from running
- tinifier wasn't getting the url from newly uploaded media items 
- I enabled statistics for counting media items in blob storage

Tested in 8.9.1 and 8.6.1